### PR TITLE
Add shortcut keys, force shutdown in main menu

### DIFF
--- a/AtomTablePlugin/main.c
+++ b/AtomTablePlugin/main.c
@@ -375,13 +375,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, ATOM_TABLE_MENUITEM, L"Atom Table", NULL), -1);
+    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, ATOM_TABLE_MENUITEM, L"&Atom Table", NULL), -1);
 }
 
 VOID NTAPI MenuItemCallback(

--- a/DnsCachePlugin/main.c
+++ b/DnsCachePlugin/main.c
@@ -348,13 +348,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, DNSCACHE_MENUITEM, L"DNS Cache Table", NULL), -1);
+    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, DNSCACHE_MENUITEM, L"&DNS Cache Table", NULL), -1);
 }
 
 VOID NTAPI MenuItemCallback(

--- a/FirewallMonitorPlugin/main.c
+++ b/FirewallMonitorPlugin/main.c
@@ -92,13 +92,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, bootMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, 1, L"Firewall Table", NULL), -1);
+    PhInsertEMenuItem(systemMenu, bootMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, 1, L"&Firewall Table", NULL), -1);
 
     if (!PhGetOwnTokenAttributes().Elevated)
     {

--- a/FirmwarePlugin/main.c
+++ b/FirmwarePlugin/main.c
@@ -91,13 +91,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, bootMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, BOOT_ENTRIES_MENUITEM, L"Firmware Table", NULL), -1);
+    PhInsertEMenuItem(systemMenu, bootMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, BOOT_ENTRIES_MENUITEM, L"Firm&ware Table", NULL), -1);
 
     if (!PhGetOwnTokenAttributes().Elevated)
     {

--- a/ForceShutdownPlugin/main.c
+++ b/ForceShutdownPlugin/main.c
@@ -76,8 +76,8 @@ VOID TrayMenuInitializingCallback(
         return;
 
     PhInsertEMenuItem(menu, PhCreateEMenuItem(PH_EMENU_SEPARATOR, 0, NULL, NULL, NULL), -1);
-    PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, REBOOT_MENU_ITEM, L"Force reboot", NULL), -1);
-    PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, SHUTDOWN_MENU_ITEM, L"Force shut down", NULL), -1);
+    PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, REBOOT_MENU_ITEM, L"F&orce reboot", NULL), -1);
+    PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, SHUTDOWN_MENU_ITEM, L"For&ce shut down", NULL), -1);
 }
 
 LOGICAL DllMain(

--- a/ForceShutdownPlugin/main.c
+++ b/ForceShutdownPlugin/main.c
@@ -29,6 +29,7 @@
 static PPH_PLUGIN PluginInstance;
 static PH_CALLBACK_REGISTRATION MenuItemCallbackRegistration;
 static PH_CALLBACK_REGISTRATION TrayMenuInitializingCallbackRegistration;
+static PH_CALLBACK_REGISTRATION MainMenuInitializingCallbackRegistration;
 
 VOID MenuItemCallback(
     _In_opt_ PVOID Parameter,
@@ -80,6 +81,27 @@ VOID TrayMenuInitializingCallback(
     PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, SHUTDOWN_MENU_ITEM, L"For&ce shut down", NULL), -1);
 }
 
+VOID MainMenuInitializingCallback(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+    )
+{
+    PPH_PLUGIN_MENU_INFORMATION menuInfo = Parameter;
+    PPH_EMENU_ITEM menu;
+
+    if (menuInfo->u.MainMenu.SubMenuIndex != 0) // 0 = Hacker menu
+        return;
+
+    menu = PhFindEMenuItem(menuInfo->Menu, 0, L"Computer", 0);
+
+    if (!menu)
+        return;
+ 
+    PhInsertEMenuItem(menu, PhCreateEMenuItem(PH_EMENU_SEPARATOR, 0, NULL, NULL, NULL), -1);
+    PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, REBOOT_MENU_ITEM, L"F&orce reboot", NULL), -1);
+    PhInsertEMenuItem(menu, PhPluginCreateEMenuItem(PluginInstance, 0, SHUTDOWN_MENU_ITEM, L"For&ce shut down", NULL), -1);
+}
+
 LOGICAL DllMain(
     _In_ HINSTANCE Instance,
     _In_ ULONG Reason,
@@ -111,6 +133,12 @@ LOGICAL DllMain(
             TrayMenuInitializingCallback,
             NULL, 
             &TrayMenuInitializingCallbackRegistration
+            );
+        PhRegisterCallback(
+            PhGetGeneralCallback(GeneralCallbackMainMenuInitializing),
+            MainMenuInitializingCallback,
+            NULL,
+            &MainMenuInitializingCallbackRegistration
             );
     }
 

--- a/ObjectManagerPlugin/main.c
+++ b/ObjectManagerPlugin/main.c
@@ -80,13 +80,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, WINOBJ_MENU_ITEM, L"Object Manager", NULL), -1);
+    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, WINOBJ_MENU_ITEM, L"&Object Manager", NULL), -1);
 }
 
 LOGICAL DllMain(

--- a/PoolMonPlugin/main.c
+++ b/PoolMonPlugin/main.c
@@ -56,13 +56,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
     
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, POOL_TABLE_MENUITEM, L"Pool Table", NULL), -1);
+    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, POOL_TABLE_MENUITEM, L"Poo&l Table", NULL), -1);
 }
 
 VOID NTAPI MenuItemCallback(

--- a/ProductPolicyPlugin/main.c
+++ b/ProductPolicyPlugin/main.c
@@ -229,13 +229,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, POLICY_TABLE_MENUITEM, L"Product Policy", NULL), -1);
+    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, POLICY_TABLE_MENUITEM, L"&Product Policy", NULL), -1);
 }
 
 VOID NTAPI MenuItemCallback(

--- a/ROTViewerPlugin/main.c
+++ b/ROTViewerPlugin/main.c
@@ -206,13 +206,13 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"System", 0)))
+    if (!(systemMenu = PhFindEMenuItem(menuInfo->Menu, 0, L"&System", 0)))
     {
         PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, L"", NULL), -1);
-        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"System", NULL), -1);
+        PhInsertEMenuItem(menuInfo->Menu, systemMenu = PhPluginCreateEMenuItem(PluginInstance, 0, 0, L"&System", NULL), -1);
     }
 
-    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, ROT_TABLE_MENUITEM, L"Running Object Table", NULL), -1);
+    PhInsertEMenuItem(systemMenu, PhPluginCreateEMenuItem(PluginInstance, 0, ROT_TABLE_MENUITEM, L"&Running Object Table", NULL), -1);
 }
 
 LOGICAL DllMain(

--- a/SecurityExplorerPlugin/main.c
+++ b/SecurityExplorerPlugin/main.c
@@ -61,7 +61,7 @@ VOID NTAPI MainMenuInitializingCallback(
     if (menuInfo->u.MainMenu.SubMenuIndex != PH_MENU_ITEM_LOCATION_TOOLS)
         return;
 
-    PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, 0, 1, L"Security Explorer", NULL), -1);
+    PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, 0, 1, L"Security &Explorer", NULL), -1);
 }
 
 LOGICAL DllMain(

--- a/TrustedInstallerPlugin/main.c
+++ b/TrustedInstallerPlugin/main.c
@@ -77,7 +77,7 @@ VOID NTAPI MainMenuInitializingCallback(
         return;
  
     indexOfMenuItem = PhIndexOfEMenuItem(menuInfo->Menu, runAsMenuItem);
-    runAsMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, RUNAS_MENU_ITEM, L"Run as trusted installer...", NULL);
+    runAsMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, RUNAS_MENU_ITEM, L"Run as &trusted installer...", NULL);
     PhInsertEMenuItem(menuInfo->Menu, runAsMenuItem, indexOfMenuItem + 1);
 
     if (!PhGetOwnTokenAttributes().Elevated)


### PR DESCRIPTION
First commit depends on the pull request from the main project, processhacker2/processhacker2#151

- Tools\\**​*S*​**ystem menu and contents
  - **​*A*​**tom Table
  - **​*D*​**NS Cache Table
  - **​*F*​**irewall Table
  - Firm**​*w*​**are Table
  - **​*O*​**bject Manager
  - Poo**​*l*​** Table
  - **​*P*​**roduct Policy
  - **​*R*​**unning Object Table
- Tools\Security **​*E*​**xplorer
- Hacker\Run as **​*t*​**rusted installer...
- Systray\Computer contents
  - F**​*o*​**rce reboot
  - For**​*c*​**e shut down

Second commit also adds the force shutdown items to the main program menu as well as the tray icon

I've tested the code and it compiles/runs fine on my system. Have not tried clicking the 'force shutdown' items.