### PR TITLE
Add a new column in network list

### DIFF
--- a/DnsCachePlugin/main.c
+++ b/DnsCachePlugin/main.c
@@ -763,7 +763,7 @@ VOID NTAPI NetworkItemAddedHandler(
 
     Extension->AddressValid = IsAddressValid(NetworkItem->RemoteAddressString);
     UpdateNetworkItem(NETWORK_COLUMN_ID_DNSCACHE_ROOT_QUERY, NetworkItem, Extension);
-    if (!Extension->DnsCacheValid)
+    if (!Extension->DnsCacheValid && Extension->AddressValid)
     {
         QueueDnsCacheUpdateThread();
         NetworkItem->JustResolved = TRUE;

--- a/DnsCachePlugin/main.c
+++ b/DnsCachePlugin/main.c
@@ -106,6 +106,7 @@ VOID EnumDnsCacheTable(
 {
 
     PDNS_RECORD dnsRecordPtr = TraverseDnsCacheTable();
+    PDNS_RECORD dnsRecordRootPtr = dnsRecordPtr;
     while (dnsRecordPtr)
     {
         INT itemIndex = MAXINT;
@@ -177,9 +178,9 @@ VOID EnumDnsCacheTable(
         dnsRecordPtr = dnsRecordPtr->pNext;
     }
 
-    if (dnsRecordPtr)
+    if (dnsRecordRootPtr)
     {
-        DnsRecordListFree(dnsRecordPtr, DnsFreeRecordList);
+        DnsRecordListFree(dnsRecordRootPtr, DnsFreeRecordList);
     }
 }
 

--- a/DnsCachePlugin/main.c
+++ b/DnsCachePlugin/main.c
@@ -647,7 +647,12 @@ static PDNS_RECORD _SearchRootQuery(PWCHAR RemoteAddressString, PDNS_RECORD DnsC
             }
             p = p->pNext;
         }
-        return finalResult ? finalResult : result;
+        if (finalResult)
+        {
+            DnsRecordListFree(result, DnsFreeRecordList);
+            return finalResult;
+        }
+        return result;
     }
     return NULL;
 }


### PR DESCRIPTION
New column to show the top-level DNS queries for IP addresses in dnscache.
There could be multiple DNS queries mapping to single address (multiple sites on same host).
These queries are separated by semi colon.