### PR TITLE
DPI Awareness Extras plugin

### DIFF
--- a/DpiAwarenessExtPlugin/DpiAwarenessExtPlugin.rc
+++ b/DpiAwarenessExtPlugin/DpiAwarenessExtPlugin.rc
@@ -1,0 +1,100 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION 1,0,0,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "poizan42"
+            VALUE "FileDescription", "DPI Awareness Extras plugin for Process Hacker"
+            VALUE "FileVersion", "1.0"
+            VALUE "InternalName", "poizan42.DpiAwarenessExtPlugin"
+            VALUE "LegalCopyright", "Licensed under the GNU GPL, v3."
+            VALUE "OriginalFilename", "DpiAwarenessExtPlugin.dll"
+            VALUE "ProductName", "DPI Awareness Extras plugin for Process Hacker"
+            VALUE "ProductVersion", "1.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/DpiAwarenessExtPlugin/DpiAwarenessExtPlugin.vcxproj
+++ b/DpiAwarenessExtPlugin/DpiAwarenessExtPlugin.vcxproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3A20876B-7910-4F74-8B42-D6A8445DEDB9}</ProjectGuid>
+    <RootNamespace>DpiAwarenessExtPlugin</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectName>DpiAwarenessExtPlugin</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\ExtraPlugins.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\ExtraPlugins.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\ExtraPlugins.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\ExtraPlugins.props" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dae_main.c" />
+    <ClCompile Include="dae_utils.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="dae_utils.h" />
+    <ClInclude Include="resource.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="DpiAwarenessExtPlugin.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/DpiAwarenessExtPlugin/DpiAwarenessExtPlugin.vcxproj.filters
+++ b/DpiAwarenessExtPlugin/DpiAwarenessExtPlugin.vcxproj.filters
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{A9BAC6A1-A163-4D28-B536-08579B86F662}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{7B060AEF-E9A0-4BA5-86B0-EA4E8C56074D}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{153C4012-E6AD-4CA9-BA24-C6D772B9D99F}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="dae_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="DpiAwarenessExtPlugin.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dae_main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="dae_utils.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/DpiAwarenessExtPlugin/README.md
+++ b/DpiAwarenessExtPlugin/README.md
@@ -1,0 +1,17 @@
+# DPI Awareness Extras plugin
+* Adds a "DPI awareness extended" column to the process tree which
+  1. Shows additional info about DPI awareness
+  2. Works for Windows versions before 8.1 (before GetProcessDpiAwareness was introduced)
+  
+## Flags
+Flags are shown in parenthesis after the awareness. They consists of a letter followed by a status
+which is one of
+  * `+` The flag is on
+  * `-` The flag is off
+  * `?` The status is unknown
+  
+Currently the following flags are shown
+  * `F` The DPI awareness is forced by the system, may be due to compatibility settings or desktop-composition being disabled.
+  
+## Known limitations
+On Windows 8.1+ the DPI awareness of processes on other sessions/window stations (possibly even desktops) arealways shown as Unaware, this is due to a limitation of GetProcessDpiAwareness.

--- a/DpiAwarenessExtPlugin/TODO.md
+++ b/DpiAwarenessExtPlugin/TODO.md
@@ -1,0 +1,5 @@
+* Show whether DPI awareness is locked (i.e. can't be changed anymore)
+* Show correct info for processes on other desktops for Windows 8.1+
+* Show whether processes has per-thread DPI awareness
+* List per-thread DPI awareness context info in Threads tab
+* Show processes and threads with Per-monitor v2 awareness

--- a/DpiAwarenessExtPlugin/dae_main.c
+++ b/DpiAwarenessExtPlugin/dae_main.c
@@ -1,0 +1,450 @@
+/*
+ * Process Hacker Extra Plugins -
+ *  DPI Awareness Extras Plugin
+ *
+ * Copyright (C) 2018 poizan42
+ *
+ * This file is part of Process Hacker.
+ *
+ * Process Hacker is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Process Hacker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Process Hacker.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <phdk.h>
+#include <mapimg.h>
+#include "resource.h"
+#include "dae_utils.h"
+
+#define DAE_DPIAWARENESSEXT_COLUMN_ID 1
+
+#define DAE_DPI_AWARENESS_UNKNOWN 0
+#define DAE_DPI_AWARENESS_UNAWARE 1
+#define DAE_DPI_AWARENESS_SYSTEM 2
+#define DAE_DPI_AWARENESS_PER_MONITOR 3
+
+#define DAE_DPI_AWARENESS_AWARENESS_MASK 0x3
+
+typedef struct _PROCESS_EXTENSION
+{
+    LIST_ENTRY ListEntry;
+    BOOL IsValid;
+    ULONG DpiAwarenessExt;
+} PROCESS_EXTENSION, *PPROCESS_EXTENSION;
+
+static VOID DaepUpdateDpiAwareness(PPH_PROCESS_ITEM ProcessItem, PPROCESS_EXTENSION Extension);
+
+static PPH_PLUGIN PluginInstance;
+static PH_CALLBACK_REGISTRATION TreeNewMessageCallbackRegistration;
+static PH_CALLBACK_REGISTRATION ProcessTreeNewInitializingCallbackRegistration;
+static PH_CALLBACK_REGISTRATION ProcessAddedCallbackRegistration;
+static PH_CALLBACK_REGISTRATION ProcessRemovedCallbackRegistration;
+static PH_CALLBACK_REGISTRATION ProcessesUpdatedCallbackRegistration;
+
+LIST_ENTRY ProcessListHead = { &ProcessListHead, &ProcessListHead };
+
+static VOID DaepTreeNewMessageCallback(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+    )
+{
+    PPH_PLUGIN_TREENEW_MESSAGE message = Parameter;
+
+    switch (message->Message)
+    {
+    case TreeNewGetCellText:
+        {
+            PPH_TREENEW_GET_CELL_TEXT getCellText = message->Parameter1;
+            PPH_PROCESS_NODE node;
+
+            node = (PPH_PROCESS_NODE)getCellText->Node;
+
+            switch (message->SubId)
+            {
+            case DAE_DPIAWARENESSEXT_COLUMN_ID:
+                {
+                    PPROCESS_EXTENSION extension;
+
+                    extension = PhPluginGetObjectExtension(PluginInstance, node->ProcessItem, EmProcessItemType);
+                    DaepUpdateDpiAwareness(node->ProcessItem, extension);
+                    switch (extension->DpiAwarenessExt & DAE_DPI_AWARENESS_AWARENESS_MASK)
+                    {
+                    case DAE_DPI_AWARENESS_UNKNOWN:
+                        break;
+                    case DAE_DPI_AWARENESS_UNAWARE:
+                        PhInitializeStringRef(&getCellText->Text, L"Unaware");
+                        break;
+                    case DAE_DPI_AWARENESS_SYSTEM:
+                        PhInitializeStringRef(&getCellText->Text, L"System aware");
+                        break;
+                    case DAE_DPI_AWARENESS_PER_MONITOR:
+                        PhInitializeStringRef(&getCellText->Text, L"Per-monitor aware");
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+        break;
+    }
+}
+
+static LONG NTAPI DaepDpiAwarenessExtSortFunction(
+    _In_ PVOID Node1,
+    _In_ PVOID Node2,
+    _In_ ULONG SubId,
+    _In_ PH_SORT_ORDER SortOrder,
+    _In_ PVOID Context
+    )
+{
+    PPH_PROCESS_NODE node1 = Node1;
+    PPH_PROCESS_NODE node2 = Node2;
+    PPROCESS_EXTENSION extension1 = PhPluginGetObjectExtension(PluginInstance, node1->ProcessItem, EmProcessItemType);
+    PPROCESS_EXTENSION extension2 = PhPluginGetObjectExtension(PluginInstance, node2->ProcessItem, EmProcessItemType);
+
+    DaepUpdateDpiAwareness(node1->ProcessItem, extension1);
+    DaepUpdateDpiAwareness(node2->ProcessItem, extension2);
+
+    return uintcmp(
+        extension1->DpiAwarenessExt & DAE_DPI_AWARENESS_AWARENESS_MASK,
+        extension2->DpiAwarenessExt & DAE_DPI_AWARENESS_AWARENESS_MASK);
+}
+
+static VOID DaepProcessTreeNewInitializingCallback(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+    )
+{
+    PPH_PLUGIN_TREENEW_INFORMATION info = Parameter;
+    PH_TREENEW_COLUMN column;
+
+    memset(&column, 0, sizeof(PH_TREENEW_COLUMN));
+    column.Text = L"Extended DPI awareness";
+    column.Width = 50;
+    column.Alignment = PH_ALIGN_RIGHT;
+    column.TextFlags = DT_RIGHT;
+
+    PhPluginAddTreeNewColumn(PluginInstance, info->CmData, &column,
+        DAE_DPIAWARENESSEXT_COLUMN_ID, NULL, DaepDpiAwarenessExtSortFunction);
+}
+
+
+VOID DaepProcessItemCreateCallback(
+    _In_ PVOID Object,
+    _In_ PH_EM_OBJECT_TYPE ObjectType,
+    _In_ PVOID Extension)
+{
+    PPH_PROCESS_ITEM processItem = Object;
+    PPROCESS_EXTENSION extension = Extension;
+
+    memset(extension, 0, sizeof(PROCESS_EXTENSION));
+}
+
+
+VOID DaepProcessAddedHandler(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+    )
+{
+    PPH_PROCESS_ITEM processItem = Parameter;
+    PPROCESS_EXTENSION extension = PhPluginGetObjectExtension(PluginInstance, processItem, EmProcessItemType);
+
+    InsertTailList(&ProcessListHead, &extension->ListEntry);
+}
+
+VOID DaepProcessRemovedHandler(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+    )
+{
+    PPH_PROCESS_ITEM processItem = Parameter;
+    PPROCESS_EXTENSION extension = PhPluginGetObjectExtension(PluginInstance, processItem, EmProcessItemType);
+
+    RemoveEntryList(&extension->ListEntry);
+}
+
+VOID DaepProcessesUpdatedHandler(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+)
+{
+    for (PLIST_ENTRY listEntry = ProcessListHead.Flink; listEntry != &ProcessListHead; listEntry = listEntry->Flink)
+    {
+        PPROCESS_EXTENSION extension = CONTAINING_RECORD(listEntry, PROCESS_EXTENSION, ListEntry);
+
+        // The DPI awareness defaults to unaware if not set or declared in the manifest in which case
+        // it can be changed once, so we can only be sure that it won't be changed again if it is different
+        // from Unaware.
+        if (extension->DpiAwarenessExt == DAE_DPI_AWARENESS_UNKNOWN || extension->DpiAwarenessExt == DAE_DPI_AWARENESS_UNAWARE)
+            extension->IsValid = FALSE;
+    }
+}
+
+static ULONG DaepGetGfDPIAwareOffset32(
+    /* user32VBase is the base the offset in the movzx is relative to,
+     * either the current load address if relocations are performed, or
+     * the default base if not. */
+    _In_ ULONG User32VBase,
+    _In_ PBYTE IsProcessDPIAware32)
+{
+    // 0FB605xxxxxxxx    movzx eax, gfDPIAware
+    // C3                ret
+    __try
+    {
+        if (IsProcessDPIAware32[0] == 0x0F && IsProcessDPIAware32[1] == 0xB6 &&
+            IsProcessDPIAware32[2] == 0x05 && IsProcessDPIAware32[7] == 0xC3)
+        {
+            return *(PULONG)(IsProcessDPIAware32 + 3) - User32VBase;
+        }
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return 0;
+    }
+    return 0;
+}
+
+static ULONG_PTR DaepGetGfDPIAwareOffset64(
+    _In_ PBYTE User32Base,
+    _In_ PBYTE IsProcessDPIAware64)
+{
+    // 0FB605xxxxxxxx    movzx eax,byte [rel gfDPIAware]
+    // C3                ret
+    __try
+    {
+        if (IsProcessDPIAware64[0] == 0x0F && IsProcessDPIAware64[1] == 0xB6 &&
+            IsProcessDPIAware64[2] == 0x05 && IsProcessDPIAware64[7] == 0xC3)
+        {
+            /* NB: x86_64 relative addressing is relative to start
+                   of the following instruction, hence the + 7 */
+            PBYTE gfDPIAwareOffsetAddr =
+                PTR_ADD_OFFSET(
+                    PTR_ADD_OFFSET(IsProcessDPIAware64, *(PULONG)(IsProcessDPIAware64 + 3)),
+                    7);
+            return gfDPIAwareOffsetAddr - User32Base;
+        }
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return 0;
+    }
+    return 0;
+}
+
+static void DaepInitGfDPIAwareOffset32WoW(_Out_ PULONG_PTR GfDPIAwareOffset32)
+{
+    PBYTE isProcessDPIAware32;
+    PH_STRINGREF systemRoot;
+    PPH_STRING user32FileName;
+    PH_MAPPED_IMAGE mappedImage;
+    PH_MAPPED_IMAGE_EXPORTS exports;
+    PH_MAPPED_IMAGE_EXPORT_FUNCTION isProcessDPIAwareFun;
+    NTSTATUS status;
+
+    *GfDPIAwareOffset32 = 0;
+
+    PhGetSystemRoot(&systemRoot);
+    user32FileName = PhConcatStringRefZ(&systemRoot, L"\\SysWow64\\user32.dll");
+    status = PhLoadMappedImage(user32FileName->Buffer, NULL, TRUE, &mappedImage);
+    PhDereferenceObject(user32FileName);
+    if (!NT_SUCCESS(status))
+        return;
+
+    if (!NT_SUCCESS(PhGetMappedImageExports(&exports, &mappedImage)))
+        goto CleanupExit;
+
+    if (!NT_SUCCESS(PhGetMappedImageExportFunction(
+        &exports,
+        "IsProcessDPIAware",
+        0,
+        &isProcessDPIAwareFun
+        )) || !isProcessDPIAwareFun.Function)
+        goto CleanupExit;
+    isProcessDPIAware32 = PhMappedImageRvaToVa(
+        &mappedImage,
+        PtrToUlong(isProcessDPIAwareFun.Function),
+        NULL);
+    if (isProcessDPIAware32)
+        *GfDPIAwareOffset32 = DaepGetGfDPIAwareOffset32(
+            mappedImage.NtHeaders32->OptionalHeader.ImageBase,
+            isProcessDPIAware32);
+
+CleanupExit:
+    PhUnloadMappedImage(&mappedImage);
+}
+
+#ifdef _WIN64
+#define DaepGetGfDPIAwareOffset DaepGetGfDPIAwareOffset64
+#else
+#define DaepGetGfDPIAwareOffset DaepGetGfDPIAwareOffset32
+#endif
+
+static void DaepInitDpiAwarenessValues(
+    _Out_ PVOID* GetProcessDpiAwarenessInternal,
+#ifdef _WIN64
+    _Out_ PULONG_PTR GfDPIAwareOffset32,
+#endif
+    _Out_ PULONG_PTR GfDPIAwareOffset
+    )
+{
+    PBYTE isProcessDPIAware = 0;
+    PVOID user32Base;
+
+    *GfDPIAwareOffset = 0;
+    user32Base = PhGetDllHandle(L"user32.dll");
+    if (!user32Base)
+        return;
+    if (*GetProcessDpiAwarenessInternal =
+        PhGetProcedureAddress(user32Base, "GetProcessDpiAwarenessInternal", 0))
+        return;
+    isProcessDPIAware = PhGetProcedureAddress(user32Base, "IsProcessDPIAware", 0);
+
+    if (isProcessDPIAware)
+        *GfDPIAwareOffset = DaepGetGfDPIAwareOffset(user32Base, isProcessDPIAware);
+
+#ifdef _WIN64
+    DaepInitGfDPIAwareOffset32WoW(GfDPIAwareOffset32);
+#endif
+}
+
+static VOID DaepUpdateDpiAwareness(PPH_PROCESS_ITEM ProcessItem, PPROCESS_EXTENSION Extension)
+{
+    static PH_INITONCE initOnce = PH_INITONCE_INIT;
+    static BOOL (WINAPI *getProcessDpiAwarenessInternal)(
+        _In_ HANDLE hprocess,
+        _Out_ ULONG *value
+        );
+    static ULONG_PTR gfDPIAwareOffset;
+    BOOL query_gfDPIAware32 = FALSE;
+    BOOL query_gfDPIAware64 = FALSE;
+#ifdef _WIN64
+    static ULONG_PTR gfDPIAwareOffset32;
+#endif
+
+    if (!Extension)
+        Extension = PhPluginGetObjectExtension(PluginInstance, ProcessItem, EmProcessItemType);
+
+    if (PhBeginInitOnce(&initOnce))
+    {
+        DaepInitDpiAwarenessValues(
+            (PVOID*)&getProcessDpiAwarenessInternal,
+#ifdef _WIN64
+            &gfDPIAwareOffset32,
+#endif
+            &gfDPIAwareOffset
+        );
+        PhEndInitOnce(&initOnce);
+    }
+
+    if (!getProcessDpiAwarenessInternal)
+    {
+#ifdef _WIN64
+        query_gfDPIAware32 = ProcessItem->IsWow64 &&
+            gfDPIAwareOffset32;
+        query_gfDPIAware64 = !ProcessItem->IsWow64 &&
+            gfDPIAwareOffset;
+#else
+        query_gfDPIAware32 = gfDPIAwareOffset;
+#endif
+        if (!query_gfDPIAware32 && !query_gfDPIAware64)
+            return;
+    }
+
+    if (!Extension->IsValid)
+    {
+        if (ProcessItem->QueryHandle)
+        {
+            ULONG dpiAwareness;
+
+            if (getProcessDpiAwarenessInternal)
+            {
+                if (getProcessDpiAwarenessInternal(ProcessItem->QueryHandle, &dpiAwareness))
+                    Extension->DpiAwarenessExt = dpiAwareness + 1;
+            }
+            else
+            {
+                ULONG_PTR curOffset;
+#ifdef _WIN64
+                if (ProcessItem->IsWow64)
+                    curOffset = gfDPIAwareOffset32;
+                else
+#endif
+                    curOffset = gfDPIAwareOffset;
+                PH_STRINGREF user32sr = PH_STRINGREF_INIT(L"user32.dll");
+                PVOID user32Base;
+                BOOLEAN gfDPIAware;
+
+                HANDLE processHandle = NULL;
+
+                if (!NT_SUCCESS(PhOpenProcess(&processHandle, ProcessQueryAccess | PROCESS_VM_READ, ProcessItem->ProcessId)))
+                    goto clean;
+                if (!NT_SUCCESS(
+                    DaeGetDllBaseRemote(
+                        processHandle,
+                        &user32sr,
+                        &user32Base)) || !user32Base)
+                    goto clean;
+                if (!NT_SUCCESS(
+                    NtReadVirtualMemory(
+                        processHandle,
+                        PTR_ADD_OFFSET(user32Base, curOffset),
+                        &gfDPIAware,
+                        sizeof(BOOLEAN),
+                        NULL)))
+                    goto clean;
+                Extension->DpiAwarenessExt = !!gfDPIAware + 1;
+            clean:
+                if (processHandle)
+                    NtClose(processHandle);
+            }
+        }
+
+        Extension->IsValid = TRUE;
+    }
+}
+
+LOGICAL DllMain(
+    _In_ HINSTANCE Instance,
+    _In_ ULONG Reason,
+    _Reserved_ PVOID Reserved
+    )
+{
+    if (Reason == DLL_PROCESS_ATTACH)
+    {
+        PPH_PLUGIN_INFORMATION info;
+
+        PluginInstance = PhRegisterPlugin(L"poizan42.DpiAwarenessExtPlugin", Instance, &info);
+
+        if (!PluginInstance)
+            return FALSE;
+
+        info->DisplayName = L"DPI Awareness Extras";
+        info->Description = L"Adds a column to display extended DPI awareness information as well as information on Windows versions prior to Windows 8.1.";
+        info->Author = L"poizan42";
+
+        PhRegisterCallback(PhGetPluginCallback(PluginInstance, PluginCallbackTreeNewMessage),
+            DaepTreeNewMessageCallback, NULL, &TreeNewMessageCallbackRegistration);
+        PhRegisterCallback(PhGetGeneralCallback(GeneralCallbackProcessTreeNewInitializing),
+            DaepProcessTreeNewInitializingCallback, NULL, &ProcessTreeNewInitializingCallbackRegistration);
+        PhRegisterCallback(PhGetGeneralCallback(GeneralCallbackProcessProviderAddedEvent),
+            DaepProcessAddedHandler, NULL, &ProcessAddedCallbackRegistration);
+        PhRegisterCallback(PhGetGeneralCallback(GeneralCallbackProcessProviderRemovedEvent),
+            DaepProcessRemovedHandler, NULL, &ProcessRemovedCallbackRegistration);
+        PhRegisterCallback(PhGetGeneralCallback(GeneralCallbackProcessProviderUpdatedEvent),
+            DaepProcessesUpdatedHandler, NULL, &ProcessesUpdatedCallbackRegistration);
+
+        PhPluginSetObjectExtension(PluginInstance, EmProcessItemType, sizeof(PROCESS_EXTENSION),
+            DaepProcessItemCreateCallback, NULL);
+    }
+
+    return TRUE;
+}

--- a/DpiAwarenessExtPlugin/dae_main.c
+++ b/DpiAwarenessExtPlugin/dae_main.c
@@ -32,16 +32,47 @@
 #define DAE_DPI_AWARENESS_SYSTEM 2
 #define DAE_DPI_AWARENESS_PER_MONITOR 3
 
-#define DAE_DPI_AWARENESS_AWARENESS_MASK 0x3
+#define DAE_TRIS_UNKNOWN 0
+#define DAE_TRIS_FALSE 1
+#define DAE_TRIS_TRUE 2
+
+#define DAE_TRIS_STR(x) ((x) == DAE_TRIS_UNKNOWN ? L"?" : ((x) == DAE_TRIS_TRUE ? L"+" : L"-"))
+
+ /*#define DAE_DPI_AWARENESS_LOCKED 0x8
+#define DAE_DPI_AWARENESS_PERTHREAD 0x10*/
+
+// Some flags in CLIENTINFO.CI_flags
+#define CI_INITTHREAD        0x00000008
+// This is not in any symbol file so is probably not what Microsoft calls it.
+#define CI_FORCEDPIAWARE 0x20000000
+
+// The offset of ((PCLIENTINFO)TEB->Win32ClientInfo)->CI_flags (which is TEB->Win32ClientInfo[0])
+#define CI_FLAGS_TEB64_OFFSET 0x800
+#define CI_FLAGS_TEB32_OFFSET 0x6CC
+#ifdef _WIN64
+#define CI_FLAGS_TEB_OFFSET CI_FLAGS_TEB64_OFFSET
+#else
+#define CI_FLAGS_TEB_OFFSET CI_FLAGS_TEB32_OFFSET
+#endif
 
 typedef struct _PROCESS_EXTENSION
 {
     LIST_ENTRY ListEntry;
-    BOOL IsValid;
-    ULONG DpiAwarenessExt;
+    ULONG ValidAwareness : 1;
+    ULONG ValidForced : 1;
+    ULONG ValidDescription : 1;
+    ULONG ValidSpare : 29;
+
+    ULONG DpiAwareness : 2;
+    ULONG DpiAwarenessForced : 2;
+    ULONG DpiAwarenessExtSpare : 28;
+    PPH_PROCESS_ITEM ProcessItem;
+    PSYSTEM_PROCESS_INFORMATION ExtProcessInfo;
+    WCHAR DpiAwarenessExtDescription[32];
 } PROCESS_EXTENSION, *PPROCESS_EXTENSION;
 
 static VOID DaepUpdateDpiAwareness(PPH_PROCESS_ITEM ProcessItem, PPROCESS_EXTENSION Extension);
+static VOID DaepUpdateDpiAwarenessDescription(_In_ PPROCESS_EXTENSION Extension);
 
 static PPH_PLUGIN PluginInstance;
 static PH_CALLBACK_REGISTRATION TreeNewMessageCallbackRegistration;
@@ -50,7 +81,17 @@ static PH_CALLBACK_REGISTRATION ProcessAddedCallbackRegistration;
 static PH_CALLBACK_REGISTRATION ProcessRemovedCallbackRegistration;
 static PH_CALLBACK_REGISTRATION ProcessesUpdatedCallbackRegistration;
 
-LIST_ENTRY ProcessListHead = { &ProcessListHead, &ProcessListHead };
+static LIST_ENTRY ProcessListHead = { &ProcessListHead, &ProcessListHead };
+static PVOID ExtendedProcesses;
+
+static BOOL (WINAPI *getProcessDpiAwarenessInternal)(
+    _In_ HANDLE hprocess,
+    _Out_ ULONG *value
+    );
+static ULONG_PTR gfDPIAwareOffset;
+#ifdef _WIN64
+static ULONG_PTR gfDPIAwareOffset32;
+#endif
 
 static VOID DaepTreeNewMessageCallback(
     _In_opt_ PVOID Parameter,
@@ -76,26 +117,43 @@ static VOID DaepTreeNewMessageCallback(
 
                     extension = PhPluginGetObjectExtension(PluginInstance, node->ProcessItem, EmProcessItemType);
                     DaepUpdateDpiAwareness(node->ProcessItem, extension);
-                    switch (extension->DpiAwarenessExt & DAE_DPI_AWARENESS_AWARENESS_MASK)
-                    {
-                    case DAE_DPI_AWARENESS_UNKNOWN:
-                        break;
-                    case DAE_DPI_AWARENESS_UNAWARE:
-                        PhInitializeStringRef(&getCellText->Text, L"Unaware");
-                        break;
-                    case DAE_DPI_AWARENESS_SYSTEM:
-                        PhInitializeStringRef(&getCellText->Text, L"System aware");
-                        break;
-                    case DAE_DPI_AWARENESS_PER_MONITOR:
-                        PhInitializeStringRef(&getCellText->Text, L"Per-monitor aware");
-                        break;
-                    }
+                    DaepUpdateDpiAwarenessDescription(extension);
+                    PhInitializeStringRef(&getCellText->Text, extension->DpiAwarenessExtDescription);
                 }
                 break;
             }
         }
         break;
     }
+}
+
+static VOID DaepUpdateDpiAwarenessDescription(_In_ PPROCESS_EXTENSION Extension)
+{
+    PWSTR awarenessDesc, forcedState;
+    if (Extension->ValidDescription)
+        return;
+
+    switch (Extension->DpiAwareness)
+    {
+    case DAE_DPI_AWARENESS_UNKNOWN:
+        Extension->DpiAwarenessExtDescription[0] = L'\0';
+        Extension->ValidDescription = TRUE;
+        return;
+    case DAE_DPI_AWARENESS_UNAWARE:
+        awarenessDesc = L"Unaware";
+        break;
+    case DAE_DPI_AWARENESS_SYSTEM:
+        awarenessDesc = L"System aware";
+        break;
+    case DAE_DPI_AWARENESS_PER_MONITOR:
+        awarenessDesc = L"Per-monitor aware";
+        break;
+    }
+    forcedState = DAE_TRIS_STR(Extension->DpiAwarenessForced);
+
+    swprintf(Extension->DpiAwarenessExtDescription, sizeof(Extension->DpiAwarenessExtDescription) / sizeof(WCHAR),
+        L"%s (F%s)", awarenessDesc, forcedState);
+    Extension->ValidDescription = TRUE;
 }
 
 static LONG NTAPI DaepDpiAwarenessExtSortFunction(
@@ -106,6 +164,7 @@ static LONG NTAPI DaepDpiAwarenessExtSortFunction(
     _In_ PVOID Context
     )
 {
+    LONG cmp1;
     PPH_PROCESS_NODE node1 = Node1;
     PPH_PROCESS_NODE node2 = Node2;
     PPROCESS_EXTENSION extension1 = PhPluginGetObjectExtension(PluginInstance, node1->ProcessItem, EmProcessItemType);
@@ -114,9 +173,10 @@ static LONG NTAPI DaepDpiAwarenessExtSortFunction(
     DaepUpdateDpiAwareness(node1->ProcessItem, extension1);
     DaepUpdateDpiAwareness(node2->ProcessItem, extension2);
 
-    return uintcmp(
-        extension1->DpiAwarenessExt & DAE_DPI_AWARENESS_AWARENESS_MASK,
-        extension2->DpiAwarenessExt & DAE_DPI_AWARENESS_AWARENESS_MASK);
+    cmp1 = uintcmp(
+        extension1->DpiAwareness,
+        extension2->DpiAwareness);
+    return cmp1 != 0 ? cmp1 : uintcmp(extension1->DpiAwarenessForced, extension2->DpiAwarenessForced);
 }
 
 static VOID DaepProcessTreeNewInitializingCallback(
@@ -128,7 +188,7 @@ static VOID DaepProcessTreeNewInitializingCallback(
     PH_TREENEW_COLUMN column;
 
     memset(&column, 0, sizeof(PH_TREENEW_COLUMN));
-    column.Text = L"Extended DPI awareness";
+    column.Text = L"DPI awareness extended";
     column.Width = 50;
     column.Alignment = PH_ALIGN_RIGHT;
     column.TextFlags = DT_RIGHT;
@@ -147,6 +207,7 @@ VOID DaepProcessItemCreateCallback(
     PPROCESS_EXTENSION extension = Extension;
 
     memset(extension, 0, sizeof(PROCESS_EXTENSION));
+    extension->ProcessItem = processItem;
 }
 
 
@@ -172,20 +233,87 @@ VOID DaepProcessRemovedHandler(
     RemoveEntryList(&extension->ListEntry);
 }
 
-VOID DaepProcessesUpdatedHandler(
+static int __cdecl DaepProcessInfoPidCompare(
+    _In_ const void *elem1,
+    _In_ const void *elem2
+)
+{
+    const SYSTEM_PROCESS_INFORMATION *pi1 = elem1;
+    const SYSTEM_PROCESS_INFORMATION *pi2 = elem2;
+
+    return uintptrcmp((ULONG_PTR)pi1->UniqueProcessId, (ULONG_PTR)pi2->UniqueProcessId);
+}
+
+static PSYSTEM_PROCESS_INFORMATION DaepLookupProcessInfo(
+    _In_ PSYSTEM_PROCESS_INFORMATION *OrderedProcesses,
+    _In_ HANDLE ProcessId,
+    _In_ ULONG startIdx,
+    _In_ ULONG endIdx)
+{
+    if (endIdx < startIdx)
+        return NULL;
+    if (startIdx == endIdx)
+    {
+        PSYSTEM_PROCESS_INFORMATION proc = OrderedProcesses[startIdx];
+        if (proc->UniqueProcessId == ProcessId)
+            return proc;
+        else
+            return NULL;
+    }
+    else
+    {
+        PSYSTEM_PROCESS_INFORMATION proc1;
+        ULONG mid = (startIdx + endIdx) / 2;
+        proc1 = DaepLookupProcessInfo(OrderedProcesses, ProcessId, startIdx, mid);
+        if (proc1)
+            return proc1;
+        return DaepLookupProcessInfo(OrderedProcesses, ProcessId, mid + 1, endIdx);
+    }
+}
+
+static VOID DaepProcessesUpdatedHandler(
     _In_opt_ PVOID Parameter,
     _In_opt_ PVOID Context
 )
 {
+    PVOID processes;
+    PSYSTEM_PROCESS_INFORMATION *orderedProcesses;
+    ULONG processCount = 0;
+    ULONG processIdx;
+    if (!NT_SUCCESS(PhEnumProcessesEx(&processes, SystemExtendedProcessInformation)))
+        return;
+
+    for (PSYSTEM_PROCESS_INFORMATION process = PH_FIRST_PROCESS(processes); process; process = PH_NEXT_PROCESS(process))
+    {
+        processCount++;
+    }
+    orderedProcesses = calloc(processCount, sizeof(PSYSTEM_PROCESS_INFORMATION));
+    if (!orderedProcesses)
+        return;
+    processIdx = 0;
+    for (PSYSTEM_PROCESS_INFORMATION process = PH_FIRST_PROCESS(processes); process; (process = PH_NEXT_PROCESS(process)), processIdx++)
+    {
+        orderedProcesses[processIdx] = process;
+    }
+
+    qsort(orderedProcesses, processCount, sizeof(PSYSTEM_PROCESS_INFORMATION), DaepProcessInfoPidCompare);
+
+    if (ExtendedProcesses)
+        PhFree(ExtendedProcesses);
+    ExtendedProcesses = processes;
+
     for (PLIST_ENTRY listEntry = ProcessListHead.Flink; listEntry != &ProcessListHead; listEntry = listEntry->Flink)
     {
         PPROCESS_EXTENSION extension = CONTAINING_RECORD(listEntry, PROCESS_EXTENSION, ListEntry);
+        PSYSTEM_PROCESS_INFORMATION procInfo = DaepLookupProcessInfo(orderedProcesses, extension->ProcessItem->ProcessId, 0, processCount - 1);
+        extension->ExtProcessInfo = procInfo;
 
         // The DPI awareness defaults to unaware if not set or declared in the manifest in which case
         // it can be changed once, so we can only be sure that it won't be changed again if it is different
         // from Unaware.
-        if (extension->DpiAwarenessExt == DAE_DPI_AWARENESS_UNKNOWN || extension->DpiAwarenessExt == DAE_DPI_AWARENESS_UNAWARE)
-            extension->IsValid = FALSE;
+        if (extension->DpiAwareness == DAE_DPI_AWARENESS_UNKNOWN ||
+            (extension->DpiAwareness == DAE_DPI_AWARENESS_UNAWARE && extension->DpiAwarenessForced != DAE_TRIS_TRUE))
+            extension->ValidAwareness = FALSE;
     }
 }
 
@@ -285,7 +413,7 @@ CleanupExit:
 #ifdef _WIN64
 #define DaepGetGfDPIAwareOffset DaepGetGfDPIAwareOffset64
 #else
-#define DaepGetGfDPIAwareOffset DaepGetGfDPIAwareOffset32
+#define DaepGetGfDPIAwareOffset(user32Base, isProcessDPIAware) DaepGetGfDPIAwareOffset32((ULONG)(user32Base), isProcessDPIAware)
 #endif
 
 static void DaepInitDpiAwarenessValues(
@@ -316,19 +444,89 @@ static void DaepInitDpiAwarenessValues(
 #endif
 }
 
-static VOID DaepUpdateDpiAwareness(PPH_PROCESS_ITEM ProcessItem, PPROCESS_EXTENSION Extension)
+static ULONG DaepGetDpiAwareness(_In_ PPH_PROCESS_ITEM ProcessItem, _Inout_ PHANDLE VmReadHandle)
+{
+    ULONG dpiAwareness = DAE_DPI_AWARENESS_UNKNOWN;
+    if (getProcessDpiAwarenessInternal)
+    {
+        ULONG winDpiAwareness;
+        if (getProcessDpiAwarenessInternal(ProcessItem->QueryHandle, &winDpiAwareness))
+            dpiAwareness = winDpiAwareness + 1;
+    }
+    else
+    {
+        ULONG_PTR curOffset;
+#ifdef _WIN64
+        if (ProcessItem->IsWow64)
+            curOffset = gfDPIAwareOffset32;
+        else
+#endif
+            curOffset = gfDPIAwareOffset;
+        PH_STRINGREF user32sr = PH_STRINGREF_INIT(L"user32.dll");
+        PVOID user32Base;
+        BOOLEAN gfDPIAware;
+
+        if (!*VmReadHandle)
+        {
+            if (!NT_SUCCESS(PhOpenProcess(VmReadHandle, ProcessQueryAccess | PROCESS_VM_READ, ProcessItem->ProcessId)))
+                return DAE_DPI_AWARENESS_UNKNOWN;
+        }
+        if (!NT_SUCCESS(
+            DaeGetDllBaseRemote(
+                *VmReadHandle,
+                &user32sr,
+                &user32Base)) || !user32Base)
+            return DAE_DPI_AWARENESS_UNKNOWN;
+        if (!NT_SUCCESS(
+            NtReadVirtualMemory(
+                *VmReadHandle,
+                PTR_ADD_OFFSET(user32Base, curOffset),
+                &gfDPIAware,
+                sizeof(BOOLEAN),
+                NULL)))
+            return DAE_DPI_AWARENESS_UNKNOWN;
+        dpiAwareness = !!gfDPIAware + 1;
+    }
+    return dpiAwareness;
+}
+
+static ULONG DaepGetDpiAwarenessForced(_In_ PPROCESS_EXTENSION Extension, _Inout_ PHANDLE VmReadHandle)
+{
+    PSYSTEM_PROCESS_INFORMATION procInfo = Extension->ExtProcessInfo;
+    if (!procInfo || procInfo->NumberOfThreads == 0)
+        return DAE_TRIS_UNKNOWN;
+
+    if (!*VmReadHandle)
+    {
+        if (!NT_SUCCESS(PhOpenProcess(VmReadHandle, ProcessQueryAccess | PROCESS_VM_READ, Extension->ProcessItem->ProcessId)))
+            return DAE_TRIS_UNKNOWN;
+    }
+
+    for (ULONG i = 0; i < procInfo->NumberOfThreads; i++)
+    {
+        ULONG ciFlags = 0;
+        PSYSTEM_EXTENDED_THREAD_INFORMATION threadInfo = (PSYSTEM_EXTENDED_THREAD_INFORMATION)procInfo->Threads + i;
+        if (!threadInfo->TebBase)
+            continue;
+        if (!NT_SUCCESS(NtReadVirtualMemory(
+                *VmReadHandle,
+                PTR_ADD_OFFSET(threadInfo->TebBase, CI_FLAGS_TEB_OFFSET),
+                &ciFlags,
+                sizeof(ciFlags),
+                NULL)))
+            continue;
+        if (ciFlags & CI_INITTHREAD)
+            return (ciFlags & CI_FORCEDPIAWARE) ? DAE_TRIS_TRUE : DAE_TRIS_FALSE;
+    }
+    return DAE_TRIS_UNKNOWN;
+}
+
+static VOID DaepUpdateDpiAwareness(_In_ PPH_PROCESS_ITEM ProcessItem, _In_opt_ PPROCESS_EXTENSION Extension)
 {
     static PH_INITONCE initOnce = PH_INITONCE_INIT;
-    static BOOL (WINAPI *getProcessDpiAwarenessInternal)(
-        _In_ HANDLE hprocess,
-        _Out_ ULONG *value
-        );
-    static ULONG_PTR gfDPIAwareOffset;
     BOOL query_gfDPIAware32 = FALSE;
     BOOL query_gfDPIAware64 = FALSE;
-#ifdef _WIN64
-    static ULONG_PTR gfDPIAwareOffset32;
-#endif
+    HANDLE vmReadHandle = NULL;
 
     if (!Extension)
         Extension = PhPluginGetObjectExtension(PluginInstance, ProcessItem, EmProcessItemType);
@@ -359,57 +557,32 @@ static VOID DaepUpdateDpiAwareness(PPH_PROCESS_ITEM ProcessItem, PPROCESS_EXTENS
             return;
     }
 
-    if (!Extension->IsValid)
+    if (!Extension->ValidAwareness)
     {
+        ULONG oldDpiAwareness = Extension->DpiAwareness;
         if (ProcessItem->QueryHandle)
         {
-            ULONG dpiAwareness;
-
-            if (getProcessDpiAwarenessInternal)
-            {
-                if (getProcessDpiAwarenessInternal(ProcessItem->QueryHandle, &dpiAwareness))
-                    Extension->DpiAwarenessExt = dpiAwareness + 1;
-            }
-            else
-            {
-                ULONG_PTR curOffset;
-#ifdef _WIN64
-                if (ProcessItem->IsWow64)
-                    curOffset = gfDPIAwareOffset32;
-                else
-#endif
-                    curOffset = gfDPIAwareOffset;
-                PH_STRINGREF user32sr = PH_STRINGREF_INIT(L"user32.dll");
-                PVOID user32Base;
-                BOOLEAN gfDPIAware;
-
-                HANDLE processHandle = NULL;
-
-                if (!NT_SUCCESS(PhOpenProcess(&processHandle, ProcessQueryAccess | PROCESS_VM_READ, ProcessItem->ProcessId)))
-                    goto clean;
-                if (!NT_SUCCESS(
-                    DaeGetDllBaseRemote(
-                        processHandle,
-                        &user32sr,
-                        &user32Base)) || !user32Base)
-                    goto clean;
-                if (!NT_SUCCESS(
-                    NtReadVirtualMemory(
-                        processHandle,
-                        PTR_ADD_OFFSET(user32Base, curOffset),
-                        &gfDPIAware,
-                        sizeof(BOOLEAN),
-                        NULL)))
-                    goto clean;
-                Extension->DpiAwarenessExt = !!gfDPIAware + 1;
-            clean:
-                if (processHandle)
-                    NtClose(processHandle);
-            }
+            Extension->DpiAwareness = DaepGetDpiAwareness(ProcessItem, &vmReadHandle);
         }
 
-        Extension->IsValid = TRUE;
+        Extension->ValidAwareness = TRUE;
+        Extension->ValidDescription = Extension->ValidDescription && oldDpiAwareness == Extension->DpiAwareness;
     }
+
+    if (!Extension->ValidForced)
+    {
+        ULONG oldDpiAwarenessForced = Extension->DpiAwarenessForced;
+        if (ProcessItem->QueryHandle)
+        {
+            Extension->DpiAwarenessForced = DaepGetDpiAwarenessForced(Extension, &vmReadHandle);
+        }
+
+        Extension->ValidForced = TRUE;
+        Extension->ValidDescription = Extension->ValidDescription && oldDpiAwarenessForced == Extension->DpiAwarenessForced;
+    }
+
+    if (vmReadHandle)
+        NtClose(vmReadHandle);
 }
 
 LOGICAL DllMain(

--- a/DpiAwarenessExtPlugin/dae_utils.c
+++ b/DpiAwarenessExtPlugin/dae_utils.c
@@ -1,0 +1,79 @@
+/*
+ * Process Hacker Extra Plugins -
+ *  DPI Awareness Extras Plugin
+ *
+ * Copyright (C) 2018 poizan42
+ *
+ * This file is part of Process Hacker.
+ *
+ * Process Hacker is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Process Hacker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Process Hacker.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <phdk.h>
+#include "dae_utils.h"
+
+typedef struct _GET_DLL_BASE_REMOTE_CONTEXT
+{
+    PH_STRINGREF BaseDllName;
+    PVOID DllBase;
+} GET_DLL_BASE_REMOTE_CONTEXT, *PGET_DLL_BASE_REMOTE_CONTEXT;
+
+static BOOLEAN DaepGetDllBaseRemoteCallback(
+    _In_ PLDR_DATA_TABLE_ENTRY Module,
+    _In_opt_ PVOID Context
+)
+{
+    PGET_DLL_BASE_REMOTE_CONTEXT context = Context;
+    PH_STRINGREF baseDllName;
+
+    PhUnicodeStringToStringRef(&Module->BaseDllName, &baseDllName);
+
+    if (PhEqualStringRef(&baseDllName, &context->BaseDllName, TRUE))
+    {
+        context->DllBase = Module->DllBase;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+NTSTATUS DaeGetDllBaseRemote(
+    _In_ HANDLE ProcessHandle,
+    _In_ PPH_STRINGREF BaseDllName,
+    _Out_ PVOID *DllBase
+)
+{
+    NTSTATUS status;
+    GET_DLL_BASE_REMOTE_CONTEXT context;
+#ifdef _WIN64
+    BOOLEAN isWow64 = FALSE;
+#endif
+
+    context.BaseDllName = *BaseDllName;
+    context.DllBase = NULL;
+
+#ifdef _WIN64
+    PhGetProcessIsWow64(ProcessHandle, &isWow64);
+
+    if (isWow64)
+        status = PhEnumProcessModules32(ProcessHandle, DaepGetDllBaseRemoteCallback, &context);
+    if (!context.DllBase)
+#endif
+        status = PhEnumProcessModules(ProcessHandle, DaepGetDllBaseRemoteCallback, &context);
+
+    if (NT_SUCCESS(status))
+        *DllBase = context.DllBase;
+
+    return status;
+}

--- a/DpiAwarenessExtPlugin/dae_utils.h
+++ b/DpiAwarenessExtPlugin/dae_utils.h
@@ -1,0 +1,31 @@
+/*
+ * Process Hacker Extra Plugins -
+ *  DPI Awareness Extras Plugin
+ *
+ * Copyright (C) 2018 poizan42
+ *
+ * This file is part of Process Hacker.
+ *
+ * Process Hacker is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Process Hacker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Process Hacker.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <phdk.h>
+
+NTSTATUS DaeGetDllBaseRemote(
+    _In_ HANDLE ProcessHandle,
+    _In_ PPH_STRINGREF BaseDllName,
+    _Out_ PVOID *DllBase
+);

--- a/DpiAwarenessExtPlugin/resource.h
+++ b/DpiAwarenessExtPlugin/resource.h
@@ -1,0 +1,15 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by DpiAwarenessExtPlugin.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/ExtraPlugins.sln
+++ b/ExtraPlugins.sln
@@ -56,6 +56,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MemoryExtPlugin", "MemoryEx
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiveDumpPlugin", "LiveDumpPlugin\LiveDumpPlugin.vcxproj", "{C913699F-D231-4FED-BE4B-4A89E875CBDA}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DpiAwarenessExtPlugin", "DpiAwarenessExtPlugin\DpiAwarenessExtPlugin.vcxproj", "{3A20876B-7910-4F74-8B42-D6A8445DEDB9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -260,6 +262,14 @@ Global
 		{C913699F-D231-4FED-BE4B-4A89E875CBDA}.Release|Win32.Build.0 = Release|Win32
 		{C913699F-D231-4FED-BE4B-4A89E875CBDA}.Release|x64.ActiveCfg = Release|x64
 		{C913699F-D231-4FED-BE4B-4A89E875CBDA}.Release|x64.Build.0 = Release|x64
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Debug|Win32.Build.0 = Debug|Win32
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Debug|x64.ActiveCfg = Debug|x64
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Debug|x64.Build.0 = Debug|x64
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Release|Win32.ActiveCfg = Release|Win32
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Release|Win32.Build.0 = Release|Win32
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Release|x64.ActiveCfg = Release|x64
+		{3A20876B-7910-4F74-8B42-D6A8445DEDB9}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# DPI Awareness Extras plugin
* Adds a "DPI awareness extended" column to the process tree which
  1. Shows additional info about DPI awareness
  2. Works for Windows versions before 8.1 (before GetProcessDpiAwareness was introduced)
  
## Flags
Flags are shown in parenthesis after the awareness. They consists of a letter followed by a status
which is one of
  * `+` The flag is on
  * `-` The flag is off
  * `?` The status is unknown
  
Currently the following flags are shown
  * `F` The DPI awareness is forced by the system, may be due to compatibility settings or desktop-composition being disabled.
  
## Known limitations
On Windows 8.1+ the DPI awareness of processes on other sessions/window stations (possibly even desktops) are always shown as Unaware, this is due to a limitation of GetProcessDpiAwareness.