### PR TITLE
PhLoadLibrarySafe and ban LoadLibrary

### DIFF
--- a/DnsCachePlugin/main.c
+++ b/DnsCachePlugin/main.c
@@ -784,7 +784,7 @@ static VOID InitDnsApi(
     VOID
     )
 {
-    if (DnsApiHandle = LoadLibrary(L"dnsapi.dll"))
+    if (DnsApiHandle = PhLoadLibrarySafe(L"dnsapi.dll"))
     {
         DnsGetCacheDataTable_I = PhGetProcedureAddress(DnsApiHandle, "DnsGetCacheDataTable", 0);
         DnsFlushResolverCache_I = PhGetProcedureAddress(DnsApiHandle, "DnsFlushResolverCache", 0);

--- a/NvGpuPlugin/nvidia.c
+++ b/NvGpuPlugin/nvidia.c
@@ -204,10 +204,10 @@ BOOLEAN InitializeNvApi(
     NvGpuNvmlHandleList = PhCreateList(1);
 
 #ifdef _M_IX86
-    if (!(NvApiLibrary = LoadLibrary(L"nvapi.dll")))
+    if (!(NvApiLibrary = PhLoadLibrarySafe(L"nvapi.dll")))
         return FALSE;
 #else
-    if (!(NvApiLibrary = LoadLibrary(L"nvapi64.dll")))
+    if (!(NvApiLibrary = PhLoadLibrarySafe(L"nvapi64.dll")))
         return FALSE;
 #endif
 
@@ -297,7 +297,7 @@ BOOLEAN InitializeNvApi(
     //NvAPI_GetDisplayDriverCompileType = NvAPI_QueryInterface(0x988AEA78);
     //NvAPI_GetDisplayDriverSecurityLevel = NvAPI_QueryInterface(0x9D772BBA);
 
-    if (NvmlLibrary = LoadLibrary(L"nvml.dll"))
+    if (NvmlLibrary = PhLoadLibrarySafe(L"nvml.dll"))
     {
         NvmlInit = PhGetProcedureAddress(NvmlLibrary, "nvmlInit", 0);
         NvmlInit_v2 = PhGetProcedureAddress(NvmlLibrary, "nvmlInit_v2", 0);

--- a/SbieSupport/main.c
+++ b/SbieSupport/main.c
@@ -231,7 +231,7 @@ VOID NTAPI LoadCallback(
 
     sbieDllPath = PhaGetStringSetting(SETTING_NAME_SBIE_DLL_PATH);
     sbieDllPath = PH_AUTO(PhExpandEnvironmentStrings(&sbieDllPath->sr));
-    module = LoadLibrary(sbieDllPath->Buffer);
+    module = PhLoadLibrarySafe(sbieDllPath->Buffer);
 
     if (module)
     {
@@ -549,7 +549,7 @@ VOID NTAPI ReloadSandboxieLibrary(
 
     if (PhGetDllHandle(sbieDllPath->Buffer))
         return;
-    if (!(module = LoadLibrary(sbieDllPath->Buffer)))
+    if (!(module = PhLoadLibrarySafe(sbieDllPath->Buffer)))
         return;
 
     PhAcquireQueuedLockExclusive(&BoxedProcessesLock);

--- a/WaitChainPlugin/main.c
+++ b/WaitChainPlugin/main.c
@@ -37,7 +37,7 @@ BOOLEAN WaitChainRegisterCallbacks(
     PCOGETCALLSTATE coGetCallStateCallback = NULL;
     PCOGETACTIVATIONSTATE coGetActivationStateCallback = NULL;
 
-    if (!(Context->Ole32ModuleHandle = LoadLibrary(L"ole32.dll")))
+    if (!(Context->Ole32ModuleHandle = PhLoadLibrarySafe(L"ole32.dll")))
         return FALSE;
 
     if (!(coGetCallStateCallback = PhGetProcedureAddress(Context->Ole32ModuleHandle, "CoGetCallState", 0)))


### PR DESCRIPTION
This PR updates `plugins-extra` to use `PsLoadLibrarySafe` instead of the now deprecated `LoadLibrary`.

Please see the primary PR here: https://github.com/processhacker/processhacker/pull/835